### PR TITLE
feat: add markdown blocks rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,6 +547,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "futf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
+dependencies = [
+ "mac",
+ "new_debug_unreachable",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -701,6 +711,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "htmd"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad1642def6e8e4dc182941f35454f7d2af917787f91f3f5133300030b41006d0"
+dependencies = [
+ "html5ever",
+ "markup5ever_rcdom",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13771afe0e6e846f1e67d038d4cb29998a6779f93c809212e4e9c32efd244d4"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "http"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -809,7 +843,7 @@ dependencies = [
  "num_cpus",
  "pcre2",
  "phf 0.8.0",
- "phf_codegen",
+ "phf_codegen 0.8.0",
  "polyglot_tokenizer",
  "regex",
  "serde",
@@ -1094,6 +1128,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
 name = "markdown"
 version = "1.0.0-alpha.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1101,6 +1141,32 @@ checksum = "911a8325e6fb87b89890cd4529a2ab34c2669c026279e61c26b7140a3d821ccb"
 dependencies = [
  "serde",
  "unicode-id",
+]
+
+[[package]]
+name = "markup5ever"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16ce3abbeba692c8b8441d036ef91aea6df8da2c6b6e21c7e14d3c18e526be45"
+dependencies = [
+ "log",
+ "phf 0.11.2",
+ "phf_codegen 0.11.2",
+ "string_cache",
+ "string_cache_codegen",
+ "tendril",
+]
+
+[[package]]
+name = "markup5ever_rcdom"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edaa21ab3701bfee5099ade5f7e1f84553fd19228cf332f13cd6e964bf59be18"
+dependencies = [
+ "html5ever",
+ "markup5ever",
+ "tendril",
+ "xml5ever",
 ]
 
 [[package]]
@@ -1358,8 +1424,18 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbffee61585b0411840d3ece935cce9cb6321f01c45477d30066498cd5e1a815"
 dependencies = [
- "phf_generator",
+ "phf_generator 0.8.0",
  "phf_shared 0.8.0",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a"
+dependencies = [
+ "phf_generator 0.11.2",
+ "phf_shared 0.11.2",
 ]
 
 [[package]]
@@ -1373,10 +1449,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_generator"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
+dependencies = [
+ "phf_shared 0.10.0",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+dependencies = [
+ "phf_shared 0.11.2",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "phf_shared"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
 dependencies = [
  "siphasher",
 ]
@@ -1455,6 +1560,12 @@ checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
  "zerocopy",
 ]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro2"
@@ -1918,6 +2029,7 @@ dependencies = [
  "devicons",
  "dirs",
  "emojis",
+ "htmd",
  "hyperpolyglot",
  "image 0.25.2",
  "include_dir",
@@ -2106,6 +2218,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "string_cache"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
+dependencies = [
+ "new_debug_unreachable",
+ "once_cell",
+ "parking_lot",
+ "phf_shared 0.10.0",
+ "precomputed-hash",
+ "serde",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb30289b722be4ff74a408c3cc27edeaad656e06cb1fe8fa9231fa59c728988"
+dependencies = [
+ "phf_generator 0.10.0",
+ "phf_shared 0.10.0",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2167,6 +2305,17 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "tendril"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+dependencies = [
+ "futf",
+ "mac",
+ "utf-8",
 ]
 
 [[package]]
@@ -2476,6 +2625,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "v_frame"
@@ -2876,6 +3031,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "xml5ever"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bbb26405d8e919bc1547a5aa9abc95cbfa438f04844f5fdd9dc7596b748bf69"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ inkjet = { version = "0.10.5", features = ["all_languages", "theme"] }
 ansi_colours = "1.2.3"
 hyperpolyglot = "0.1.7"
 devicons = "0.1.0"
+htmd = "0.1.6"
 
 
 # The profile that 'cargo dist' will build with

--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@
 <img width="1363" alt="image" src="https://github.com/user-attachments/assets/bd253204-deca-4756-bbba-60272e0a367c">
 
 Markdown it's special 🐈
+
 <img width="1363" alt="image" src="https://github.com/user-attachments/assets/b4c3c3ef-8ba5-4ab5-8a3d-55556ca02536">
 
 And Images 🖼️ 📷
 
 https://github.com/user-attachments/assets/106c18e6-61ef-4fbd-89f1-883ae028467d
 
-
 > [!WARNING]  
-> **DISCLAIMER: This project is currently in alpha stage. It may contain bugs, incomplete features, or undergo significant changes. Use with caution and please report any issues you encounter.**
+> This project is currently in alpha stage. It may contain bugs, incomplete features, or undergo significant changes. Use with caution and please report any issues you encounter.\*\*
 
 see is a powerful file visualization tool for the terminal, offering advanced code viewing capabilities, Markdown rendering, and more. It provides syntax highlighting, emoji support, and image rendering capabilities, offering a visually appealing way to view various file types directly in your console.
 
@@ -31,7 +31,7 @@ see is a powerful file visualization tool for the terminal, offering advanced co
 
 # Motivation and Context
 
-The primary goal of **see** *(smd before v0.4.0)*  was to create a unified tool for viewing both CLI documentation in Markdown and code files, renderable in both the terminal and web browse
+The primary goal of **see** _(smd before v0.4.0)_ was to create a unified tool for viewing both CLI documentation in Markdown and code files, renderable in both the terminal and web browse
 
 As the project evolved from its initial focus on Markdown, support for viewing code files was added, expanding its utility in diverse development ecosystems. Now, see is your go-to tool for seeing everything that a cat can see!
 
@@ -85,7 +85,8 @@ There are several ways to install see:
 The easiest and fastest way to install see is by using our shell script:
 
 > [!IMPORTANT]  
-> **DISCLAIMER: The version number in the URL bellow (v0.5.2) may not be the latest version. Please check the [releases page](https://github.com/guilhermeprokisch/see/releases) for the most recent version and update the URL accordingly before running the command.**
+> The version number in the URL bellow (v0.5.2) may not be the latest version. Please check the [releases page](https://github.com/guilhermeprokisch/see/releases) for the most recent version and update the URL accordingly before running the command.\*\*
+
 ```sh
 curl --proto '=https' --tlsv1.2 -LsSf https://github.com/guilhermeprokisch/see/releases/download/v0.5.2/see-cat-installer.sh | sh
 ```

--- a/docs/main.md
+++ b/docs/main.md
@@ -25,6 +25,7 @@ If FILE is not provided, see reads from standard input.
 | `--show-filename`        | Show or hide the filename before rendering content  |
 | `--config <file>`        | Specify a custom configuration file                 |
 | `--use-color`            | Control color output                                |
+| `--convert-html`         | Enable or disable HTML to Markdown conversion       |
 
 ## Examples
 
@@ -86,4 +87,10 @@ Render content without showing the filename:
 
 ```bash
 see --show-filename=false path/to/your/markdown_file.md
+```
+
+Convert HTML to Markdown:
+
+```bash
+see --convert-html=true path/to/your/file_with_html.md
 ```

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,6 +23,7 @@ pub struct AppConfig {
     pub show_filename: bool,
     pub debug_mode: bool,
     pub use_colors: bool,
+    pub convert_html: bool,
 }
 
 impl AppConfig {
@@ -50,7 +51,7 @@ impl AppConfig {
 
     fn default_config() -> Self {
         AppConfig {
-            max_image_width: Some(40),
+            max_image_width: Some(100),
             max_image_height: Some(13),
             render_images: true,
             render_links: true,
@@ -59,6 +60,7 @@ impl AppConfig {
             show_filename: false,
             debug_mode: false,
             use_colors: true,
+            convert_html: true,
         }
     }
 
@@ -125,6 +127,7 @@ fn parse_cli_args() -> io::Result<(AppConfig, Option<Vec<PathBuf>>)> {
                 "show-line-numbers" => {
                     config.show_line_numbers = parse_bool(parts.get(1).map(|s| *s))
                 }
+                "convert-html" => config.convert_html = parse_bool(parts.get(1).map(|s| *s)),
                 "show-filename" => config.show_filename = parse_bool(parts.get(1).map(|s| *s)),
                 "use-colors" => config.use_colors = parse_bool(parts.get(1).map(|s| *s)),
                 "config" => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,11 +44,9 @@ fn main() -> std::io::Result<()> {
         }
         None => {
             let content = app::read_content(None)?;
-            viewer_manager.visualize(
-                &["markdown".to_string(), "code".to_string()],
-                &content,
-                None,
-            )?;
+            // It uses the markdown viewer by default.
+            // Could be changed to use the first viewer from the config file in the future?
+            viewer_manager.visualize(&["markdown".to_string()], &content, None)?;
         }
     }
 


### PR DESCRIPTION
This PR introduces HTML to Markdown conversion functionality. The main changes include:

1. Added a new configuration option `convert_html` to enable/disable HTML to Markdown conversion.
2. Implemented HTML to Markdown conversion using the `htmd` crate.
3. Updated the `render_node` function to handle HTML nodes and convert them to Markdown when enabled.
4. Added error handling and debug logging for image rendering issues.
5. Updated documentation to reflect the new `--convert-html` CLI option.
6. Adjusted default image dimensions for better display.