### PR TITLE
feat: concatenate output and support base64 image encoding 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2025,6 +2025,7 @@ name = "see-cat"
 version = "0.7.1"
 dependencies = [
  "ansi_colours",
+ "base64 0.22.1",
  "crossterm 0.28.1",
  "devicons",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ ansi_colours = "1.2.3"
 hyperpolyglot = "0.1.7"
 devicons = "0.1.0"
 htmd = "0.1.6"
+base64 = "0.22.1"
 
 
 # The profile that 'cargo dist' will build with

--- a/src/render.rs
+++ b/src/render.rs
@@ -6,9 +6,11 @@ use std::collections::HashMap;
 use std::io::{self, Write};
 use std::path::PathBuf;
 
+use base64::{engine::general_purpose, Engine as _};
 use std::sync::atomic::Ordering;
 use std::sync::Mutex;
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
+
 use url::Url;
 
 use crate::config::get_config;
@@ -406,7 +408,31 @@ pub fn render_image(node: &Value) -> io::Result<()> {
     }
 
     let url = node["url"].as_str().unwrap_or("");
-    render_image_file(url)
+
+    if url.starts_with("data:image") {
+        // Handle base64 encoded image
+        let parts: Vec<&str> = url.split(',').collect();
+        if parts.len() == 2 {
+            let b64_data = parts[1];
+            let decoded = general_purpose::STANDARD
+                .decode(b64_data)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+            // Create a temporary file
+            let mut temp_file = tempfile::NamedTempFile::new()?;
+            temp_file.write_all(&decoded)?;
+            let temp_path = temp_file.into_temp_path();
+
+            render_image_file(temp_path.to_str().unwrap())
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Invalid base64 image data",
+            ))
+        }
+    } else {
+        render_image_file(url)
+    }
 }
 
 pub fn render_image_file(path: &str) -> io::Result<()> {

--- a/src/viewers.rs
+++ b/src/viewers.rs
@@ -2,6 +2,7 @@ use crate::app;
 use crate::config::get_config;
 use crate::render::{render_code_file, render_image_file, render_markdown};
 use crate::utils::detect_language;
+use base64::{engine::general_purpose, Engine as _};
 use devicons::{icon_for_file, File, Theme};
 use std::collections::HashMap;
 use std::io::{self, Write};
@@ -96,13 +97,34 @@ impl Viewer for CodeViewer {
 struct ImageViewer;
 
 impl Viewer for ImageViewer {
-    fn visualize(&self, _content: &str, file_path: Option<&str>) -> io::Result<()> {
+    fn visualize(&self, content: &str, file_path: Option<&str>) -> io::Result<()> {
         if let Some(path) = file_path {
             render_image_file(path)
+        } else if content.starts_with("data:image") {
+            // Handle base64 encoded image
+            let parts: Vec<&str> = content.split(',').collect();
+            if parts.len() == 2 {
+                let b64_data = parts[1];
+                let decoded = general_purpose::STANDARD
+                    .decode(b64_data)
+                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+                // Create a temporary file
+                let mut temp_file = tempfile::NamedTempFile::new()?;
+                temp_file.write_all(&decoded)?;
+                let temp_path = temp_file.into_temp_path();
+
+                render_image_file(temp_path.to_str().unwrap())
+            } else {
+                Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "Invalid base64 image data",
+                ))
+            }
         } else {
             Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
-                "No file path provided for image rendering",
+                "No file path or valid base64 image data provided for image rendering",
             ))
         }
     }


### PR DESCRIPTION
## Summary
This PR introduces the ability to concatenate output from multiple files, including support for base64-encoded images. This enhancement improves the functionality of the `see` command when redirecting output to a file, especially for markdown documents with embedded images.

## Key Changes
1. Added base64 support to encode images in the output.
2. Modified the main function to handle image files differently when stdout is not a terminal.
3. Updated the `render_image` function to support base64-encoded image data.
4. Enhanced the `ImageViewer` to visualize both file paths and base64 image data.

## Implementation Details
- Added the `base64` crate as a new dependency.
- In `main.rs`, images are now encoded to base64 and output as markdown image tags when redirecting.
- `render.rs` now includes logic to decode and render base64 image data.
- `viewers.rs` has been updated to handle base64-encoded images in the `ImageViewer`.

## Impact
These changes allow users to:
- Concatenate multiple files, including images, into a single output file.
- Generate markdown-compatible output with embedded base64 images.
- View base64-encoded images directly in the terminal.

## Example Usage
```bash
see file1.md image.png file2.md > output.md
```
This command will now produce a single markdown file with the content of `file1.md`, the image embedded as a base64-encoded markdown image tag, and the content of `file2.md`.
