### PR TITLE
fix: preserve whitespace around inline bold/italic spans (#82)

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -160,16 +160,17 @@ fn format_text(text: &str) -> String {
     let leading = text.starts_with(char::is_whitespace);
     let trailing = text.ends_with(char::is_whitespace);
 
-    let mut out = String::new();
+    let mut out = String::with_capacity(text.len());
     if leading {
         out.push(' ');
     }
 
-    let words: Vec<&str> = text.split_whitespace().collect();
-    for (i, word) in words.iter().enumerate() {
-        if i > 0 {
+    let mut has_content = false;
+    for word in text.split_whitespace() {
+        if has_content {
             out.push(' ');
         }
+        has_content = true;
         if let Some(emoji) = parse_emoji(word) {
             out.push_str(&emoji);
         } else {
@@ -179,7 +180,7 @@ fn format_text(text: &str) -> String {
 
     // Only emit a trailing space when there was actual content; for a
     // whitespace-only node the leading space above already represents it.
-    if trailing && !words.is_empty() {
+    if trailing && has_content {
         out.push(' ');
     }
 
@@ -428,8 +429,9 @@ fn render_link(node: &Value) -> io::Result<()> {
     if !config.render_links {
         render_children(node)?;
     } else {
-        // Add a space before the link reference
-        print!(" ");
+        // No surrounding spaces here: adjacent text nodes carry their own
+        // boundary whitespace (see format_text), so padding here would double
+        // the spaces around the link.
         // Start OSC 8 hyperlink
         print!("\x1B]8;;{}\x1B\\", url);
 
@@ -445,9 +447,6 @@ fn render_link(node: &Value) -> io::Result<()> {
 
         // End OSC 8 hyperlink
         print!("\x1B]8;;\x1B\\");
-
-        // Add a space after the link reference
-        print!(" ");
     }
 
     Ok(())
@@ -561,7 +560,9 @@ fn render_delete(node: &Value) -> io::Result<()> {
 fn render_inline_code(node: &Value) -> io::Result<()> {
     let mut stdout = StandardStream::stdout(ColorChoice::Always);
     stdout.set_color(ColorSpec::new().set_fg(Some(Color::Yellow)).set_bold(true))?;
-    print!(" {} ", node["value"].as_str().unwrap_or(""));
+    // No surrounding spaces here: adjacent text nodes carry their own boundary
+    // whitespace (see format_text), so padding here would double the spaces.
+    print!("{}", node["value"].as_str().unwrap_or(""));
     stdout.reset()?;
     Ok(())
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -143,20 +143,47 @@ fn render_heading(node: &Value) -> io::Result<()> {
 }
 
 fn render_text(node: &Value) -> io::Result<()> {
-    let text = node["value"].as_str().unwrap_or("");
-    let words: Vec<&str> = text.split_whitespace().collect();
+    print!("{}", format_text(node["value"].as_str().unwrap_or("")));
+    Ok(())
+}
 
+/// Render a text node to a string, normalizing internal whitespace runs
+/// (including soft line breaks) to single spaces while preserving the
+/// whitespace at the boundaries of the node.
+///
+/// Preserving the boundary whitespace keeps inline spans like **bold** or
+/// *italic* separated from adjacent text. The parser splits
+/// "The **controller** runs" into the text node "The ", a strong node, and the
+/// text node " runs"; collapsing those boundary spaces would glue the words
+/// together ("Thecontrollerruns").
+fn format_text(text: &str) -> String {
+    let leading = text.starts_with(char::is_whitespace);
+    let trailing = text.ends_with(char::is_whitespace);
+
+    let mut out = String::new();
+    if leading {
+        out.push(' ');
+    }
+
+    let words: Vec<&str> = text.split_whitespace().collect();
     for (i, word) in words.iter().enumerate() {
         if i > 0 {
-            print!(" ");
+            out.push(' ');
         }
         if let Some(emoji) = parse_emoji(word) {
-            print!("{}", emoji);
+            out.push_str(&emoji);
         } else {
-            print!("{}", word);
+            out.push_str(word);
         }
     }
-    Ok(())
+
+    // Only emit a trailing space when there was actual content; for a
+    // whitespace-only node the leading space above already represents it.
+    if trailing && !words.is_empty() {
+        out.push(' ');
+    }
+
+    out
 }
 
 fn parse_emoji(word: &str) -> Option<String> {
@@ -831,4 +858,56 @@ fn render_html(node: &Value) -> io::Result<()> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_text;
+
+    #[test]
+    fn preserves_space_before_inline_span() {
+        // Text node that precedes a **bold** span keeps its trailing space.
+        assert_eq!(format_text("The "), "The ");
+    }
+
+    #[test]
+    fn preserves_space_after_inline_span() {
+        // Text node that follows a **bold** span keeps its leading space.
+        assert_eq!(format_text(" runs"), " runs");
+    }
+
+    #[test]
+    fn preserves_both_boundary_spaces() {
+        assert_eq!(format_text(" and decides "), " and decides ");
+    }
+
+    #[test]
+    fn normalizes_internal_whitespace() {
+        assert_eq!(format_text("foo   bar\nbaz"), "foo bar baz");
+    }
+
+    #[test]
+    fn preserves_boundaries_while_normalizing_internal() {
+        assert_eq!(format_text("  foo   bar  "), " foo bar ");
+    }
+
+    #[test]
+    fn whitespace_only_node_collapses_to_single_space() {
+        assert_eq!(format_text("   "), " ");
+    }
+
+    #[test]
+    fn empty_node_stays_empty() {
+        assert_eq!(format_text(""), "");
+    }
+
+    #[test]
+    fn no_boundary_whitespace_is_untouched() {
+        assert_eq!(format_text("controller"), "controller");
+    }
+
+    #[test]
+    fn expands_emoji_shortcodes() {
+        assert_eq!(format_text("hello :smile:"), "hello 😄");
+    }
 }

--- a/tests/inline_spacing.rs
+++ b/tests/inline_spacing.rs
@@ -1,0 +1,99 @@
+//! End-to-end checks that inline spans render with exactly one space around
+//! them — covering both the dropped-space bug around **bold**/*italic* and the
+//! double-space regression around `code` spans and links.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Render `markdown` with the real `see` binary and return the visible text,
+/// with ANSI/OSC escape sequences stripped. `name` keeps the temp input file
+/// unique so tests running in parallel don't clobber each other's input.
+fn render(name: &str, markdown: &str) -> String {
+    let dir = PathBuf::from(env!("CARGO_TARGET_TMPDIR"));
+    let path = dir.join(format!("{name}.md"));
+    fs::write(&path, markdown).expect("write input markdown");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_see"))
+        // Force the rich markdown viewer even though stdout is a pipe, and turn
+        // the pager off so the rendered output lands on stdout directly.
+        .env("SEE_FORCE_INTERACTIVE", "1")
+        .arg("--pager=false")
+        .arg(&path)
+        .output()
+        .expect("run see");
+    assert!(
+        output.status.success(),
+        "see exited with {:?}",
+        output.status
+    );
+
+    strip_ansi(&String::from_utf8_lossy(&output.stdout))
+}
+
+/// Remove ANSI CSI sequences (`ESC [ ... m`) and OSC 8 hyperlinks
+/// (`ESC ] 8 ; ; ... ST`) so assertions can look at the plain text.
+fn strip_ansi(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c != '\u{1b}' {
+            out.push(c);
+            continue;
+        }
+        match chars.next() {
+            // CSI: consume until a final byte in the range 0x40..=0x7e.
+            Some('[') => {
+                for f in chars.by_ref() {
+                    if ('\u{40}'..='\u{7e}').contains(&f) {
+                        break;
+                    }
+                }
+            }
+            // OSC: consume until the string terminator (ESC \) or BEL.
+            Some(']') => {
+                while let Some(f) = chars.next() {
+                    if f == '\u{07}' {
+                        break;
+                    }
+                    if f == '\u{1b}' {
+                        if matches!(chars.peek(), Some('\\')) {
+                            chars.next();
+                        }
+                        break;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    out
+}
+
+#[test]
+fn inline_code_and_links_render_with_single_spaces() {
+    let rendered = render(
+        "code_and_links",
+        "Use `code` now and a [link](http://example.com) here.\n",
+    );
+    assert!(
+        rendered.contains("Use code now and a link here."),
+        "expected single spaces around inline code and link, got: {rendered:?}"
+    );
+    assert!(
+        !rendered.contains("  "),
+        "rendered output should not contain double spaces, got: {rendered:?}"
+    );
+}
+
+#[test]
+fn bold_and_italic_keep_surrounding_spaces() {
+    let rendered = render(
+        "bold_and_italic",
+        "The **controller** runs and decides *what* next.\n",
+    );
+    assert!(
+        rendered.contains("The controller runs and decides what next."),
+        "expected spaces preserved around bold/italic spans, got: {rendered:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #82 — inline spans were rendered with the wrong spacing:

1. **Spaces were dropped** around `**bold**` / `*italic*`, gluing the styled word to its neighbours (e.g. `The controller runs` rendered as `Thecontrollerruns`). This is the originally reported bug.
2. **Double spaces** then showed up around `` `code` `` spans and links once boundary spaces were preserved (see below).

## Root cause

`render_text` in `src/render.rs` tokenized each text node with `split_whitespace()` and re-joined with single spaces. `split_whitespace()` discards the leading/trailing whitespace of the node. The Markdown parser splits `The **controller** runs` into the text node `"The "`, a `strong` node, and the text node `" runs"`; the trailing space of `"The "` and the leading space of `" runs"` were thrown away.

Preserving that boundary whitespace surfaced a second problem: `render_inline_code` and `render_link` hardcoded their *own* surrounding spaces (`" {} "` and a space before/after the link). With the adjacent text nodes now keeping their spaces too, `Use `code` now` and `a [link](url) here` rendered with double spaces.

## Changes

- `render_text` / new `format_text()` helper: preserve a single (collapsed) space at each boundary of a text node when present, while still normalizing internal whitespace runs — including soft line breaks — to single spaces. Whitespace-only nodes collapse to a single space; empty nodes stay empty.
- `render_inline_code` and `render_link`: drop the hardcoded surrounding spaces and rely on the adjacent text nodes' preserved boundary whitespace, matching how `render_strong` / `render_emphasis` already work.

## Tests

- Unit tests for `format_text` covering boundary spaces (before/after/both), internal whitespace normalization, the combination of the two, whitespace-only nodes, empty nodes, untouched no-boundary text, and emoji shortcode expansion.
- An end-to-end test (`tests/inline_spacing.rs`) that renders Markdown through the real `see` binary, strips ANSI, and asserts single spaces around inline code, links, bold and italic.

All pass (`cargo test`).

## Verification

```
$ printf 'The **controller** runs and a [link](http://x) and `code` here.\n' > t.md
$ see t.md
The controller runs and a link and code here.
```

(bold/italic/link/code styling applied, single spaces throughout)
