### PR TITLE
fix: render soft and hard line breaks within paragraphs (#84)

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -74,6 +74,7 @@ fn render_node(node: &Value) -> io::Result<()> {
         Some("listItem") => render_list_item(node)?,
         Some("blockquote") => render_blockquote(node)?,
         Some("thematicBreak") => render_thematic_break()?,
+        Some("break") => render_break()?,
         Some("link") => render_link(node)?,
         Some("image") => render_image(node)?,
         Some("emphasis") => render_emphasis(node)?,
@@ -143,13 +144,24 @@ fn render_heading(node: &Value) -> io::Result<()> {
 }
 
 fn render_text(node: &Value) -> io::Result<()> {
-    print!("{}", format_text(node["value"].as_str().unwrap_or("")));
+    let text = node["value"].as_str().unwrap_or("");
+
+    // A newline inside a text value is a soft line break. Split on it so each
+    // source line stays on its own line (as pagers like glow render markdown)
+    // instead of letting format_text collapse it into a single space.
+    for (line_idx, line) in text.split('\n').enumerate() {
+        if line_idx > 0 {
+            render_break()?;
+        }
+        print!("{}", format_text(line));
+    }
     Ok(())
 }
 
-/// Render a text node to a string, normalizing internal whitespace runs
-/// (including soft line breaks) to single spaces while preserving the
-/// whitespace at the boundaries of the node.
+/// Render a single text line to a string, normalizing internal whitespace runs
+/// to single spaces while preserving the whitespace at the boundaries of the
+/// node. Soft line breaks are handled by the caller (`render_text`), which
+/// splits on newlines before calling this.
 ///
 /// Preserving the boundary whitespace keeps inline spans like **bold** or
 /// *italic* separated from adjacent text. The parser splits
@@ -404,6 +416,19 @@ fn render_paragraph(node: &Value) -> io::Result<()> {
     }
     render_children(node)?;
     println!();
+    Ok(())
+}
+
+fn render_break() -> io::Result<()> {
+    // Soft and hard line breaks: end the current line and re-apply the
+    // paragraph indent so the continuation aligns (unless inside a list item,
+    // matching render_paragraph).
+    println!();
+    if let Ok(list_stack) = LIST_STACK.lock() {
+        if list_stack.is_empty() {
+            print!("{}", get_indent());
+        }
+    }
     Ok(())
 }
 

--- a/tests/line_breaks.rs
+++ b/tests/line_breaks.rs
@@ -1,0 +1,106 @@
+//! End-to-end checks that line breaks within a paragraph render on separate
+//! lines: soft breaks (a single source newline) and hard breaks (two trailing
+//! spaces or a backslash). Regression test for #84, where soft breaks were
+//! silently collapsed into the surrounding text.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Render `markdown` with the real `see` binary and return the visible text,
+/// with ANSI/OSC escape sequences stripped. `name` keeps the temp input file
+/// unique so tests running in parallel don't clobber each other's input.
+fn render(name: &str, markdown: &str) -> String {
+    let dir = PathBuf::from(env!("CARGO_TARGET_TMPDIR"));
+    let path = dir.join(format!("{name}.md"));
+    fs::write(&path, markdown).expect("write input markdown");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_see"))
+        // Force the rich markdown viewer even though stdout is a pipe, and turn
+        // the pager off so the rendered output lands on stdout directly.
+        .env("SEE_FORCE_INTERACTIVE", "1")
+        .arg("--pager=false")
+        .arg(&path)
+        .output()
+        .expect("run see");
+    assert!(
+        output.status.success(),
+        "see exited with {:?}",
+        output.status
+    );
+
+    strip_ansi(&String::from_utf8_lossy(&output.stdout))
+}
+
+/// Remove ANSI CSI sequences (`ESC [ ... m`) and OSC 8 hyperlinks
+/// (`ESC ] 8 ; ; ... ST`) so assertions can look at the plain text.
+fn strip_ansi(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c != '\u{1b}' {
+            out.push(c);
+            continue;
+        }
+        match chars.next() {
+            Some('[') => {
+                for f in chars.by_ref() {
+                    if ('\u{40}'..='\u{7e}').contains(&f) {
+                        break;
+                    }
+                }
+            }
+            Some(']') => {
+                while let Some(f) = chars.next() {
+                    if f == '\u{07}' {
+                        break;
+                    }
+                    if f == '\u{1b}' {
+                        if matches!(chars.peek(), Some('\\')) {
+                            chars.next();
+                        }
+                        break;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    out
+}
+
+#[test]
+fn soft_line_breaks_stay_on_separate_lines() {
+    // Single newlines within one paragraph (soft breaks). Previously these were
+    // collapsed, gluing the lines together.
+    let rendered = render(
+        "soft_breaks",
+        "**Date:** 2026-06-22\n**Work item:** here\n**Design:** there\n",
+    );
+    assert!(
+        rendered.contains("Date: 2026-06-22\n"),
+        "first line should end at the soft break, got: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("Work item: here\n"),
+        "second line should be on its own line, got: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("Design: there"),
+        "third line should be on its own line, got: {rendered:?}"
+    );
+    assert!(
+        !rendered.contains("2026-06-22Work item"),
+        "soft-broken lines must not be glued together, got: {rendered:?}"
+    );
+}
+
+#[test]
+fn hard_line_breaks_stay_on_separate_lines() {
+    // Two trailing spaces before the newline is a hard break.
+    let rendered = render("hard_breaks", "line one  \nline two\n");
+    assert!(
+        rendered.contains("line one\nline two"),
+        "hard break should split the two lines, got: {rendered:?}"
+    );
+}


### PR DESCRIPTION
Fixes #84.

## Root cause

The issue proposed adding a `Some("break") => println!()` arm to `render_node`. I dumped the mdast AST and found that only half-fixes it:

- **Soft** line breaks are **not** emitted as `break` nodes — the `markdown` crate keeps the `\n` *inside* the `Text` node value (e.g. `" 2026-06-22\n"`). `format_text` then collapsed it (via `split_whitespace`) into a space, so the break vanished. This is the actual cause of the reported bug.
- **Hard** breaks (two trailing spaces or `\`) *do* produce a `break` node, which had no arm.

## Fix

Rebased onto current `main` (on top of #83, which refactored text rendering into the pure `format_text` helper).

- **`render_text`**: split the text value on `\n` and render each segment via the existing `format_text` helper, emitting a line break between segments so each source line stays on its own line (glow-style).
- **`render_break`** + a `Some("break")` arm for hard breaks, emitting a newline plus the paragraph indent (skipped inside list items, matching `render_paragraph`).
- **`tests/line_breaks.rs`**: end-to-end regression tests for soft and hard breaks, using the same harness #83 introduced.

## Verification

Full suite passes (`cargo test`): the `format_text` unit tests, the inline-spacing e2e tests from #83, and the two new line-break tests. The issue's reproduction now renders:
```
Date: 2026-06-22
Work item: work_items/18
Design: file.md
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)