### PR TITLE
ci: push release tag with RELEASE_BOT so release.yml auto-triggers

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -22,6 +22,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # Use the PAT so the tag push below is authored by a real user token.
+          # Tags pushed with the default GITHUB_TOKEN do NOT trigger other
+          # workflows, which is why release.yml (the GitHub Release build) never
+          # fired on tag pushes and had to be dispatched manually.
+          token: ${{ secrets.RELEASE_BOT }}
       - name: Extract version from commit message or input
         id: extract_version
         run: |


### PR DESCRIPTION
## Problem

Releases were only half-automated. When a `chore(main): release X.Y.Z` commit landed, `tag.yaml` created and pushed the tag using the default `GITHUB_TOKEN`. GitHub deliberately **does not trigger other workflows** from events created by `GITHUB_TOKEN`, so `release.yml` (the cargo-dist GitHub Release build) never fired on the tag push — the GitHub Release had to be created by manually dispatching `release.yml` every time.

This is exactly what happened with v0.9.2: crates.io published, but the GitHub Release was missing until dispatched by hand.

## Fix

Have `actions/checkout` in the `create-tag` job persist the `RELEASE_BOT` PAT. Then `git push origin v$VERSION` is authored by a real user token, whose push **does** trigger the `push: tags:` event in `release.yml` — so the Release build runs automatically.

One-line-ish change; no behavior change beyond the tag now being pushed with the PAT.

## Requirement

Depends on the `RELEASE_BOT` secret being a valid (non-expired) PAT with Contents: read/write on this repo. (It expired, which is being renewed separately.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)