### PR TITLE
feat: render YAML/TOML frontmatter as a metadata header

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -51,6 +51,10 @@ pub fn parse_and_process_markdown_with_config(
     apply_terminal_tweaks: bool,
 ) -> io::Result<Value> {
     let mut md_options = markdown::ParseOptions::gfm();
+    // Recognize YAML/TOML frontmatter so it is emitted as a dedicated node
+    // instead of being misparsed (a closing `---` otherwise turns the block
+    // into a setext heading).
+    md_options.constructs.frontmatter = true;
     if !config.render_links {
         md_options.constructs.autolink = false;
         md_options.constructs.gfm_autolink_literal = false;

--- a/src/render.rs
+++ b/src/render.rs
@@ -65,6 +65,7 @@ fn render_node(node: &Value) -> io::Result<()> {
 
     match node["type"].as_str() {
         Some("root") => render_children(node)?,
+        Some("yaml") | Some("toml") => render_frontmatter(node)?,
         Some("heading") => render_heading(node)?,
         Some("paragraph") => render_paragraph(node)?,
         Some("text") => render_text(node)?,
@@ -141,6 +142,116 @@ fn render_heading(node: &Value) -> io::Result<()> {
     }
 
     Ok(())
+}
+
+/// Render a YAML/TOML frontmatter block as a compact metadata header.
+///
+/// The parser hands us the raw block between the `---` fences. We render each
+/// flat `key: value` line as an aligned pair — keys in a muted color, and a
+/// few well-known keys (`status`, `priority`) get their value colored by
+/// meaning. Lines we can't split on `:` (nested/multiline YAML) are printed
+/// verbatim so nothing is silently dropped.
+fn render_frontmatter(node: &Value) -> io::Result<()> {
+    let config = get_config();
+    let raw = node["value"].as_str().unwrap_or("");
+    let mut stdout = get_stdout();
+
+    let entries: Vec<(&str, &str)> = raw
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        // YAML uses `key: value`; TOML frontmatter (`+++`) uses `key = value`.
+        .map(|line| match line.split_once(':').or_else(|| line.split_once('=')) {
+            Some((key, value)) => (key.trim(), value.trim()),
+            None => (line.trim(), ""),
+        })
+        .collect();
+
+    if entries.is_empty() {
+        return Ok(());
+    }
+
+    let key_width = entries
+        .iter()
+        .map(|(key, _)| key.chars().count())
+        .max()
+        .unwrap_or(0);
+
+    println!();
+    for (key, value) in &entries {
+        print!("{}", get_indent());
+
+        // Dim left gutter bar marks the block as a distinct metadata region
+        // without drawing a horizontal rule across the terminal.
+        if config.use_colors {
+            stdout.set_color(ColorSpec::new().set_dimmed(true))?;
+        }
+        print!("│ ");
+        if config.use_colors {
+            stdout.reset()?;
+        }
+
+        // Keys are dimmed (not a heading color) so metadata reads as chrome and
+        // never gets mistaken for an H1, which is bold cyan.
+        if config.use_colors {
+            stdout.set_color(ColorSpec::new().set_dimmed(true))?;
+        }
+        print!("{:<width$}", key, width = key_width);
+        if config.use_colors {
+            stdout.reset()?;
+        }
+
+        if value.is_empty() {
+            println!();
+            continue;
+        }
+
+        print!("   ");
+        let value_color = frontmatter_value_color(key, value);
+        if config.use_colors {
+            let mut spec = ColorSpec::new();
+            match value_color {
+                Some(color) => {
+                    spec.set_fg(Some(color)).set_bold(true);
+                }
+                None if key.eq_ignore_ascii_case("title") => {
+                    spec.set_bold(true);
+                }
+                None => {}
+            }
+            stdout.set_color(&spec)?;
+        }
+        print!("{}", value);
+        if config.use_colors {
+            stdout.reset()?;
+        }
+        println!();
+    }
+    println!();
+
+    Ok(())
+}
+
+/// Pick a semantic color for a few well-known frontmatter values so task-style
+/// metadata reads at a glance. Returns `None` for keys/values we don't
+/// recognize, leaving them in the default color.
+fn frontmatter_value_color(key: &str, value: &str) -> Option<Color> {
+    let normalized = value.trim().trim_matches('"').to_ascii_lowercase();
+    match key.to_ascii_lowercase().as_str() {
+        "status" => match normalized.as_str() {
+            "done" | "completed" | "complete" | "closed" => Some(Color::Green),
+            "in_progress" | "in-progress" | "doing" | "active" | "wip" => Some(Color::Blue),
+            "blocked" | "waiting" | "on_hold" | "on-hold" => Some(Color::Red),
+            "pending" | "todo" | "open" | "backlog" => Some(Color::Yellow),
+            _ => None,
+        },
+        "priority" => match normalized.as_str() {
+            "high" | "urgent" | "critical" | "p0" | "p1" => Some(Color::Red),
+            "medium" | "med" | "normal" | "p2" => Some(Color::Yellow),
+            "low" | "minor" | "p3" | "p4" => Some(Color::Green),
+            _ => None,
+        },
+        _ => None,
+    }
 }
 
 fn render_text(node: &Value) -> io::Result<()> {

--- a/tests/frontmatter.rs
+++ b/tests/frontmatter.rs
@@ -1,0 +1,109 @@
+//! End-to-end checks that YAML frontmatter renders as a metadata header rather
+//! than being misparsed. Without the frontmatter construct enabled, a closing
+//! `---` turns the block into a setext heading, so `id: "001"` etc. rendered as
+//! one bold heading line. These tests pin the metadata-block behavior.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Render `markdown` with the real `see` binary and return the visible text,
+/// with ANSI/OSC escape sequences stripped.
+fn render(name: &str, markdown: &str) -> String {
+    let dir = PathBuf::from(env!("CARGO_TARGET_TMPDIR"));
+    let path = dir.join(format!("{name}.md"));
+    fs::write(&path, markdown).expect("write input markdown");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_see"))
+        .env("SEE_FORCE_INTERACTIVE", "1")
+        .arg("--pager=false")
+        .arg(&path)
+        .output()
+        .expect("run see");
+    assert!(output.status.success(), "see exited with {:?}", output.status);
+
+    strip_ansi(&String::from_utf8_lossy(&output.stdout))
+}
+
+/// Remove ANSI CSI sequences (`ESC [ ... m`) and OSC 8 hyperlinks so assertions
+/// can look at the plain text.
+fn strip_ansi(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c != '\u{1b}' {
+            out.push(c);
+            continue;
+        }
+        match chars.next() {
+            Some('[') => {
+                for f in chars.by_ref() {
+                    if ('\u{40}'..='\u{7e}').contains(&f) {
+                        break;
+                    }
+                }
+            }
+            Some(']') => {
+                while let Some(f) = chars.next() {
+                    if f == '\u{07}' {
+                        break;
+                    }
+                    if f == '\u{1b}' {
+                        if matches!(chars.peek(), Some('\\')) {
+                            chars.next();
+                        }
+                        break;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    out
+}
+
+const TASK_DOC: &str = "---\nid: \"001\"\ntitle: \"My first task\"\nstatus: pending\npriority: medium\n---\n\n# My First Task\n\nBody text.\n";
+
+#[test]
+fn frontmatter_keys_render_on_their_own_lines() {
+    let rendered = render("frontmatter_keys", TASK_DOC);
+    // Each key sits on its own line with its value, not collapsed into one
+    // heading line the way the setext-heading misparse produced.
+    for expected in ["id", "title", "status", "priority"] {
+        assert!(
+            rendered.lines().any(|line| {
+                // Each metadata line is `│ <key> ...`; strip the gutter first.
+                line.trim_start()
+                    .trim_start_matches('│')
+                    .trim_start()
+                    .starts_with(expected)
+            }),
+            "expected a metadata line for {expected:?}, got: {rendered:?}"
+        );
+    }
+    assert!(
+        rendered.contains("pending"),
+        "status value should be shown, got: {rendered:?}"
+    );
+}
+
+#[test]
+fn frontmatter_fences_are_not_rendered() {
+    // The `---` fences must be consumed by the parser, never printed as text.
+    let rendered = render("frontmatter_fences", TASK_DOC);
+    assert!(
+        !rendered.contains("---"),
+        "frontmatter fences should not appear in output, got: {rendered:?}"
+    );
+}
+
+#[test]
+fn frontmatter_does_not_swallow_following_heading() {
+    // Regression: the closing `---` used to fold the body's first heading into
+    // the frontmatter. The real document heading must still render.
+    let rendered = render("frontmatter_heading", TASK_DOC);
+    assert!(
+        rendered.contains("My First Task"),
+        "document heading should still render, got: {rendered:?}"
+    );
+}


### PR DESCRIPTION
## What

Renders YAML/TOML frontmatter as a compact metadata header instead of misparsing it.

Before, a file like:

```
---
id: "001"
title: "My first task"
status: pending
priority: high
---
```

was rendered as **one mangled bold line** — the closing `---` fence acts as a setext-heading underline, folding the whole block into an H2.

Now it renders as an aligned key/value block with a dim left gutter:

```
│ id            001
│ title         My first task      (bold)
│ status        pending            (yellow)
│ priority      high               (red)
```

## Details

- **[src/app.rs](../blob/main/src/app.rs)** — enable `constructs.frontmatter` so the parser emits a dedicated `yaml`/`toml` node.
- **[src/render.rs](../blob/main/src/render.rs)** — `render_frontmatter`: dim left gutter bar (no horizontal rule), dimmed keys (distinct from the bold-cyan H1), semantic value coloring for `status`/`priority`. Lines that can't split on `:`/`=` print verbatim, so nested YAML is never dropped.
- Generic: works for any frontmatter (Obsidian, Astro, Hugo, Zettelkasten), taskmd just gets the status/priority coloring for free. Kept as a *renderer*, not a task app.

## Tests

Added [tests/frontmatter.rs](../blob/main/tests/frontmatter.rs): keys on their own lines, fences never printed, following heading survives. Full suite green (15 unit + 7 integration), clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)