### PR TITLE
fix: render inline formatting inside table cells (#90)

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -345,8 +345,44 @@ fn render_code(node: &Value) -> io::Result<()> {
     Ok(())
 }
 
-fn render_table(node: &Value) -> io::Result<()> {
+/// Visible text of a table cell, applying the same inline transforms used when
+/// rendering (emoji/whitespace normalization for text, raw value for code) so
+/// column widths line up with what is actually printed. Formatting wrappers
+/// (strong/emphasis/link/…) contribute their inner text rather than being
+/// dropped.
+fn cell_display_text(node: &Value) -> String {
+    match node["type"].as_str() {
+        Some("text") => format_text(node["value"].as_str().unwrap_or("")),
+        Some("inlineCode") => node["value"].as_str().unwrap_or("").to_string(),
+        _ => {
+            let mut out = String::new();
+            if let Some(children) = node["children"].as_array() {
+                for child in children {
+                    out.push_str(&cell_display_text(child));
+                }
+            }
+            out
+        }
+    }
+}
+
+/// Render a table cell's full inline content through the normal renderers so
+/// bold/italic/code/links are preserved. The base color is re-applied before
+/// each child so plain-text segments keep the cell color even after an
+/// emphasis/strong span resets the terminal state.
+fn render_table_cell(cell: &Value, base: &ColorSpec) -> io::Result<()> {
     let mut stdout = StandardStream::stdout(ColorChoice::Always);
+    if let Some(children) = cell["children"].as_array() {
+        for child in children {
+            stdout.set_color(base)?;
+            render_node(child)?;
+        }
+    }
+    stdout.reset()?;
+    Ok(())
+}
+
+fn render_table(node: &Value) -> io::Result<()> {
     let config = get_config();
 
     if let Some(children) = node["children"].as_array() {
@@ -356,7 +392,7 @@ fn render_table(node: &Value) -> io::Result<()> {
         for row in children {
             if let Some(cells) = row["children"].as_array() {
                 for (i, cell) in cells.iter().enumerate() {
-                    let content = cell["children"][0]["value"].as_str().unwrap_or("").len();
+                    let content = cell_display_text(cell).chars().count();
                     if i >= column_widths.len() {
                         column_widths.push(content);
                     } else if content > column_widths[i] {
@@ -381,20 +417,24 @@ fn render_table(node: &Value) -> io::Result<()> {
                 }
 
                 for (j, cell) in cells.iter().enumerate() {
-                    let content = cell["children"][0]["value"].as_str().unwrap_or("");
-
-                    // Set color for header row and first column
+                    // Base color for the header row and first column.
+                    let mut base = ColorSpec::new();
                     if i == 0 {
-                        stdout
-                            .set_color(ColorSpec::new().set_fg(Some(Color::Red)).set_bold(true))?;
+                        base.set_fg(Some(Color::Red)).set_bold(true);
                     } else if j == 0 {
-                        stdout.set_color(ColorSpec::new().set_fg(Some(Color::Cyan)))?;
+                        base.set_fg(Some(Color::Cyan));
                     } else {
-                        stdout.set_color(ColorSpec::new().set_fg(Some(Color::White)))?;
+                        base.set_fg(Some(Color::White));
                     }
 
-                    print!("{:<width$}", content, width = column_widths[j]);
-                    stdout.reset()?;
+                    // Render the cell's full inline content (bold/italic/code/
+                    // links), then right-pad to the column width. Padding is
+                    // printed uncolored, which is fine since no background is set.
+                    let visible = cell_display_text(cell).chars().count();
+                    render_table_cell(cell, &base)?;
+                    for _ in visible..column_widths[j] {
+                        print!(" ");
+                    }
 
                     if config.render_table_borders {
                         if j < cells.len() - 1 {

--- a/tests/tables.rs
+++ b/tests/tables.rs
@@ -1,0 +1,90 @@
+//! Regression test for #90: table cells that contain inline formatting
+//! (bold/italic/code) used to render only the first child's plain text, so any
+//! emphasized text — and any text after it — was silently dropped.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Render `markdown` with the real `see` binary and return the visible text,
+/// with ANSI/OSC escape sequences stripped.
+fn render(name: &str, markdown: &str) -> String {
+    let dir = PathBuf::from(env!("CARGO_TARGET_TMPDIR"));
+    let path = dir.join(format!("{name}.md"));
+    fs::write(&path, markdown).expect("write input markdown");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_see"))
+        .env("SEE_FORCE_INTERACTIVE", "1")
+        .arg("--pager=false")
+        .arg(&path)
+        .output()
+        .expect("run see");
+    assert!(output.status.success(), "see exited with {:?}", output.status);
+
+    strip_ansi(&String::from_utf8_lossy(&output.stdout))
+}
+
+/// Remove ANSI CSI sequences (`ESC [ ... m`) and OSC 8 hyperlinks so assertions
+/// can look at the plain text.
+fn strip_ansi(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c != '\u{1b}' {
+            out.push(c);
+            continue;
+        }
+        match chars.next() {
+            Some('[') => {
+                for f in chars.by_ref() {
+                    if ('\u{40}'..='\u{7e}').contains(&f) {
+                        break;
+                    }
+                }
+            }
+            Some(']') => {
+                while let Some(f) = chars.next() {
+                    if f == '\u{07}' {
+                        break;
+                    }
+                    if f == '\u{1b}' {
+                        if matches!(chars.peek(), Some('\\')) {
+                            chars.next();
+                        }
+                        break;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    out
+}
+
+const TABLE: &str = "| Test | Table |\n| --- | --- |\n| Test **row** | **data** |\n| *Another* test | _another_ data |\n";
+
+#[test]
+fn table_cells_keep_bold_and_italic_text() {
+    let rendered = render("table_formatting", TABLE);
+
+    // Text that lives inside emphasis/strong spans (and text that follows one
+    // in the same cell) must survive.
+    for expected in ["Test row", "data", "Another test", "another data"] {
+        assert!(
+            rendered.contains(expected),
+            "expected {expected:?} in rendered table, got: {rendered:?}"
+        );
+    }
+}
+
+#[test]
+fn table_cell_starting_with_bold_is_not_empty() {
+    // `**data**` has a strong node as its first (and only) child. The old code
+    // read `children[0].value`, which is empty for a strong node, dropping the
+    // whole cell.
+    let rendered = render("table_leading_bold", "| A | B |\n| --- | --- |\n| **x** | y |\n");
+    assert!(
+        rendered.contains('x'),
+        "leading-bold cell should render its text, got: {rendered:?}"
+    );
+}


### PR DESCRIPTION
## What

Fixes #90 — table cells dropped any bold/italic/code text (and any text following it).

Given:
```
| Test | Table |
| --- | --- |
| Test **row** | **data** |
| *Another* test | _another_ data |
```
`Test **row**` rendered as just `Test `, and `**data**` rendered as nothing.

## Cause

The table renderer read only `cell["children"][0]["value"]` — the first child's raw text. For `Test **row**` that's the `"Test "` text node (the `strong` node is child 1, ignored); for `**data**` the first child *is* the `strong` node, which has no `value`, so the cell came out empty.

## Fix

- Render each cell's **full inline content** through the normal renderers (`render_node`), so bold/italic/code/links are preserved.
- Compute column widths from the cell's complete visible text (`cell_display_text`, which mirrors the display transforms).
- Re-apply the cell's base color (header red / first-column cyan) before each child, so plain-text segments keep their color even after an emphasis span resets the terminal state.

## Result

```
Test          Table          (header, red bold)
Test row      data           ("row"/"data" bold)
Another test  another data   ("Another"/"another" italic)
```
Alignment preserved in both bordered and borderless modes.

## Tests

Added [tests/tables.rs](tests/tables.rs): cells keep bold/italic text, and a cell that *starts* with bold is no longer empty. Full suite green (24 tests).